### PR TITLE
Handle non existing measurement

### DIFF
--- a/custom_components/ngenic/manifest.json
+++ b/custom_components/ngenic/manifest.json
@@ -6,6 +6,6 @@
     "dependencies": [],
     "codeowners": ["@sfalkman"],
     "requirements": [
-        "ngenicpy==0.2.0"
+        "ngenicpy==0.2.1"
     ]
 }

--- a/custom_components/ngenic/sensor.py
+++ b/custom_components/ngenic/sensor.py
@@ -92,9 +92,9 @@ async def get_measurement_value(node, **kwargs):
         # measurement API will return None if no measurements were found for the period
         _LOGGER.info("Measurement not found for period, this is expected when data have not been gathered for the period (type=%s, from=%s, to=%s)" % 
             (
-                kwargs.get(measurement_type, "unknown"), 
-                kwargs.get(from_dt, "None"), 
-                kwargs.get(to_dt, "None")
+                kwargs.get("measurement_type", "unknown"), 
+                kwargs.get("from_dt", "None"), 
+                kwargs.get("to_dt", "None")
             )
         )
         measurement_val = 0


### PR DESCRIPTION
When measurement data doesn't exist for a period, the API wrapper will return `None`. In this case, we return 0 as the measurement value of the sensor.

Closes #16 