### PR TITLE
Add ControlValue OptionsFlow and RestoreState to make better use of Ngenic Trak with UtilitySensors

### DIFF
--- a/custom_components/ngenic/.translations/en.json
+++ b/custom_components/ngenic/.translations/en.json
@@ -15,5 +15,17 @@
             "bad_token": "API token was invalid",
             "no_tunes": "No Tunes was found"
         }
+    },
+    "options": {
+        "step": {
+            "options": {
+                "title": "Ngenic Options",
+                "data": {
+                    "create_utility_meters": "Create Utility Meters for Ngenic Energy Sensor",
+                    "create_current_month_sensor": "Create Polling Sensor for Current Month Energy Consumption",
+                    "create_previous_month_sensor": "Create Polling Sensor for Last Month Energy Consumption"          
+                }
+            }
+        }
     }
 }

--- a/custom_components/ngenic/.translations/sv.json
+++ b/custom_components/ngenic/.translations/sv.json
@@ -15,5 +15,17 @@
             "bad_token": "API token är felaktig",
             "no_tunes": "Hittade inga Tunes"
         }
+    },
+    "options": {
+        "step": {
+            "options": {
+                "title": "Ngenic Inställningar",
+                "data": {
+                    "create_utility_meters": "Skapa (energi)mätare för energisensorn",
+                    "create_current_month_sensor": "Skapa sensor för nuvarande månads energiförbrukning",
+                    "create_previous_month_sensor": "Skapa sensor för föregående månads energiförbrukning"          
+                }
+            }
+        }
     }
 }

--- a/custom_components/ngenic/const.py
+++ b/custom_components/ngenic/const.py
@@ -10,3 +10,7 @@ From API doc: Tune system Nodes generally report data in intervals of five
 minutes, so there is no point in polling the API for new data at a higher rate.
 """
 SCAN_INTERVAL = timedelta(seconds=(60 * 5))
+
+CONF_CREATE_UTILITY_METERS = "create_utility_meters"
+CONF_CREATE_CURRENT_MONTH_SENSOR = "create_current_month_sensor"
+CONF_CREATE_PREVIOUS_MONTH_SENSOR = "create_previous_month_sensor"

--- a/custom_components/ngenic/strings.json
+++ b/custom_components/ngenic/strings.json
@@ -15,5 +15,17 @@
             "bad_token": "API token was invalid",
             "no_tunes": "No Tunes was found"
         }
+    },
+    "options": {
+        "step": {
+            "options": {
+                "title": "Ngenic Options",
+                "data": {
+                    "create_utility_meters": "Create Utility Meters for Ngenic Energy Sensor",
+                    "create_current_month_sensor": "Create Polling Sensor for Current Month Energy Consumption",
+                    "create_previous_month_sensor": "Create Polling Sensor for Last Month Energy Consumption"          
+                }
+            }
+        }
     }
 }

--- a/custom_components/ngenic/translations/en.json
+++ b/custom_components/ngenic/translations/en.json
@@ -15,5 +15,17 @@
             "bad_token": "API token was invalid",
             "no_tunes": "No Tunes was found"
         }
+    },
+    "options": {
+        "step": {
+            "options": {
+                "title": "Ngenic Options",
+                "data": {
+                    "create_utility_meters": "Create Utility Meters for Ngenic Energy Sensor",
+                    "create_current_month_sensor": "Create Polling Sensor for Current Month Energy Consumption",
+                    "create_previous_month_sensor": "Create Polling Sensor for Last Month Energy Consumption"          
+                }
+            }
+        }
     }
 }

--- a/custom_components/ngenic/translations/sv.json
+++ b/custom_components/ngenic/translations/sv.json
@@ -15,5 +15,17 @@
             "bad_token": "API token är felaktig",
             "no_tunes": "Hittade inga Tunes"
         }
+    },
+    "options": {
+        "step": {
+            "options": {
+                "title": "Ngenic Inställningar",
+                "data": {
+                    "create_utility_meters": "Skapa (energi)mätare för energisensorn",
+                    "create_current_month_sensor": "Skapa sensor för nuvarande månads energiförbrukning",
+                    "create_previous_month_sensor": "Skapa sensor för föregående månads energiförbrukning"          
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
First off, thanks for creating this platform

This PR consists of 3 parts

# Add `NgenicControlTempSensor`

The API exposes a `CONTROL_VALUE` sensor that indicates the adjustment made by the tune on the outdoor temperature.
This value is made available in a new temperature sensor `sensor.ngenic_controller_control_value`

# Prepare Ngenic Track Energy Sensor for [UtilityMeter](https://www.home-assistant.io/integrations/utility_meter/)

As explained in [here](https://github.com/home-assistant/core/issues/20931#issuecomment-462897239) the source sensor should/could implement `RestoreEntity` to store it's state between restarts.

To cater for that the `NgenicEnergySensor` now has it's state stored and updated on load

The other change to the `NgenicEnergySensor` is that the value of `sensor.ngenic_sensor_energy` now reads the _total_ number of kWh's consumed since installation

# Add options to replace the current/previous month sensors with utility meters

The Integration now has an `OptionsFlow` that will make all additions of meters optional.

![image](https://user-images.githubusercontent.com/353148/103352137-aa2bf980-4aa5-11eb-8345-5d7d14f16e93.png)

The default setting will be to _not_ add utility meters, and _keep_ the current `sensor.ngenic_sensor_monthly_energy` and `sensor.ngenic_sensor_last_month_energy` untouched

