### PR TITLE
Home Energy Management integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ Install HACS and add the repository to the Custom repositories under HACS Settin
 
 * https://hacs.xyz/docs/installation/manual
   * https://hacs.xyz/docs/basic/getting_started
-
 ## Prerequisite
 ### Obtain an API token
 An API token may be obtained from Ngenic here: https://developer.ngenic.se/
 
 ## Configuration
 Configure via UI: Configuration > Integrations
+
+### Home Energy Management
+If you have an [Ngenic Track](https://ngenic.se/track/) you may track your energy consumption in Home Assistant's _Energy Management_.  
+
+There's one thing to consider: if your Track is placed on the energy meter you should add the _Ngenic energy sensor_ as a _Grid consumption_. If your Track is placed on something else (such as district heating meter), you should add the _Ngenic energy sensor_ as an _Individual device_.

--- a/custom_components/ngenic/manifest.json
+++ b/custom_components/ngenic/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "ngenic",
     "name": "Ngenic Tune",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "config_flow": true,
     "documentation": "https://github.com/sfalkman/ngenic-hass-platform",
     "issue_tracker": "https://github.com/sfalkman/ngenic-hass-platform/issues",

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ngenic Tune",
+  "iot_class": "Cloud Polling",
+  "homeassistant": "2021.6.0"
+}


### PR DESCRIPTION
Migrate sensors to extend `SensorEntity`.  
This, among other things, break compatibility with Home Assistant of version lower than 2021.6.0.

**Features**
Temp, humidity, power and energy sensors are now marked as measured.
This is to support long-term statistics.

The energy sensors are now marked as an energy class instead of power.
The 'total today energy' has a new property; last_reset. This is used by
the build-in Energy Management to keep track of the energy consumption (supported from 2021.8.0).

**Fixes**
The 'total today energy' will not pass a `period` to the Ngenic API,
doing so lead to missing meterings during the day.

