### PR TITLE
changing state_class for energy sensor

### DIFF
--- a/custom_components/ngenic/sensor.py
+++ b/custom_components/ngenic/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
     POWER_WATT
 )
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
+from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, STATE_CLASS_TOTAL_INCREASING, SensorEntity
 from homeassistant.helpers.event import async_track_time_interval
 import homeassistant.util.dt as dt_util
 
@@ -341,7 +341,7 @@ class NgenicPowerSensor(NgenicSensor):
         
 class NgenicEnergySensor(NgenicSensor):
     device_class = DEVICE_CLASS_ENERGY
-    state_class  = STATE_CLASS_MEASUREMENT
+    state_class  = STATE_CLASS_TOTAL_INCREASING
 
     @property
     def unit_of_measurement(self):

--- a/custom_components/ngenic/sensor.py
+++ b/custom_components/ngenic/sensor.py
@@ -348,11 +348,6 @@ class NgenicEnergySensor(NgenicSensor):
         """Return the unit of measurement."""
         return ENERGY_KILO_WATT_HOUR
 
-    @property
-    def last_reset(self):
-        """Return the time when the sensor value was last reset."""
-        return dt_util.start_of_local_day()
-
     async def _async_fetch_measurement(self):
         """Ask for measurements for a duration.
         This requires some further inputs, so we'll override the _async_fetch_measurement method.


### PR DESCRIPTION
Changing NgenicEnergySensor state_class to STATE_CLASS_TOTAL_INCREASING. This will ensure statistics are calculated correctly (instead of being treated as current measurement).

I am currently a bit unsure if last_reset should be used together with this (see docs below):
https://developers.home-assistant.io/docs/core/entity/sensor/#properties

When testing it seems to work alot better then before though.