### PR TITLE
update minimum version of home assistant

### DIFF
--- a/custom_components/ngenic/sensor.py
+++ b/custom_components/ngenic/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
     POWER_WATT
 )
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
+from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, STATE_CLASS_TOTAL_INCREASING, SensorEntity
 from homeassistant.helpers.event import async_track_time_interval
 import homeassistant.util.dt as dt_util
 
@@ -341,7 +341,7 @@ class NgenicPowerSensor(NgenicSensor):
         
 class NgenicEnergySensor(NgenicSensor):
     device_class = DEVICE_CLASS_ENERGY
-    state_class  = STATE_CLASS_MEASUREMENT
+    state_class  = STATE_CLASS_TOTAL_INCREASING
 
     @property
     def unit_of_measurement(self):

--- a/custom_components/ngenic/sensor.py
+++ b/custom_components/ngenic/sensor.py
@@ -348,11 +348,6 @@ class NgenicEnergySensor(NgenicSensor):
         """Return the unit of measurement."""
         return ENERGY_KILO_WATT_HOUR
 
-    @property
-    def last_reset(self):
-        """Return the time when the sensor value was last reset."""
-        return dt_util.start_of_local_day()
-
     async def _async_fetch_measurement(self):
         """Ask for measurements for a duration.
         This requires some further inputs, so we'll override the _async_fetch_measurement method.

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Ngenic Tune",
   "iot_class": "Cloud Polling",
-  "homeassistant": "2021.6.0"
+  "homeassistant": "2021.9.0"
 }


### PR DESCRIPTION
Since the state_class: total_increasing was introduced in 2021.9.0 we need to update the minimum requirement.

On another note, have been running beta2 now for a week and everything related to the energy/track functionality seems to be working really well!