### PR TITLE
Fixed deprecation warnings

### DIFF
--- a/custom_components/ngenic/__init__.py
+++ b/custom_components/ngenic/__init__.py
@@ -6,7 +6,8 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.helpers import config_validation as cv
 from homeassistant.const import (
-    CONF_TOKEN
+    CONF_TOKEN,
+    Platform
 )
 
 from .config_flow import configured_instances
@@ -29,11 +30,17 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+NGENIC_PLATFORMS = [
+    Platform.CLIMATE,
+    Platform.SENSOR
+]
+
+
 async def async_setup(hass, config):
     """Setup the Ngenic component"""
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][DATA_CLIENT] = {}
-    
+
     if DOMAIN not in config:
         return True
 
@@ -41,7 +48,7 @@ async def async_setup(hass, config):
 
     # Store config for use during entry setup
     hass.data[DOMAIN][DATA_CONFIG] = conf
-    
+
     # Check if already configured
     if conf[CONF_TOKEN] in configured_instances(hass):
         return True
@@ -59,6 +66,7 @@ async def async_setup(hass, config):
 
     return True
 
+
 async def async_setup_entry(hass, config_entry):
     from ngenicpy import AsyncNgenic
     ngenic = AsyncNgenic(
@@ -66,15 +74,16 @@ async def async_setup_entry(hass, config_entry):
     )
 
     hass.data[DOMAIN][DATA_CLIENT] = ngenic
-
-    for component in ("sensor", "climate"):
-        hass.async_add_job(hass.config_entries.async_forward_entry_setup(config_entry, component))
+    
+    config_entry.async_create_task(
+        hass, hass.config_entries.async_forward_entry_setups(config_entry, NGENIC_PLATFORMS)
+    )
 
     return True
 
+
 async def async_unload_entry(hass, config_entry):
-    for component in ("sensor", "climate"):
-        await hass.config_entries.async_forward_entry_unload(config_entry, component)
+    await hass.config_entries.async_unload_platforms(config_entry, NGENIC_PLATFORMS)
 
     await hass.data[DOMAIN][DATA_CLIENT].async_close()
 

--- a/custom_components/ngenic/__init__.py
+++ b/custom_components/ngenic/__init__.py
@@ -74,10 +74,8 @@ async def async_setup_entry(hass, config_entry):
     )
 
     hass.data[DOMAIN][DATA_CLIENT] = ngenic
-    
-    config_entry.async_create_task(
-        hass, hass.config_entries.async_forward_entry_setups(config_entry, NGENIC_PLATFORMS)
-    )
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, NGENIC_PLATFORMS)
 
     return True
 

--- a/custom_components/ngenic/climate.py
+++ b/custom_components/ngenic/climate.py
@@ -6,11 +6,11 @@ from ngenicpy.models.measurement import MeasurementType
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
-    SUPPORT_TARGET_TEMPERATURE,
-    HVAC_MODE_HEAT
+    ClimateEntityFeature,
+    HVACMode
 )
 from homeassistant.const import (
-    TEMP_CELSIUS, 
+    UnitOfTemperature,
     ATTR_TEMPERATURE
 )
 
@@ -87,7 +87,7 @@ class NgenicTune(ClimateEntity):
     @property
     def supported_features(self):
         """Return the list of supported features."""
-        return SUPPORT_TARGET_TEMPERATURE
+        return ClimateEntityFeature.TARGET_TEMPERATURE
 
     @property
     def name(self):
@@ -105,7 +105,7 @@ class NgenicTune(ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement which this thermostat uses."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def current_temperature(self):
@@ -120,12 +120,12 @@ class NgenicTune(ClimateEntity):
     @property
     def hvac_mode(self):
         """Must be implemented"""
-        return HVAC_MODE_HEAT
+        return HVACMode.HEAT
 
     @property
     def hvac_modes(self):
         """Must be implemented"""
-        return [HVAC_MODE_HEAT]
+        return [HVACMode.HEAT]
 
     async def async_will_remove_from_hass(self):
         """Remove updater when sensor is removed."""

--- a/custom_components/ngenic/sensor.py
+++ b/custom_components/ngenic/sensor.py
@@ -6,22 +6,21 @@ from ngenicpy.models.node import NodeType
 from ngenicpy.models.measurement import MeasurementType
 
 from homeassistant.const import (
-    TEMP_CELSIUS,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_ENERGY,
-    ENERGY_KILO_WATT_HOUR,
-    POWER_WATT
+    UnitOfTemperature,
+    UnitOfEnergy,
+    UnitOfPower
 )
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, STATE_CLASS_TOTAL_INCREASING, SensorEntity
+from homeassistant.components.sensor import (
+    SensorStateClass,
+    SensorEntity,
+    SensorDeviceClass,
+)
 from homeassistant.helpers.event import async_track_time_interval
 import homeassistant.util.dt as dt_util
 
 from .const import (
     DOMAIN,
-    DATA_CLIENT,
-    SCAN_INTERVAL
+    DATA_CLIENT
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -308,29 +307,31 @@ class NgenicSensor(SensorEntity):
             _LOGGER.debug("No new measurement (old=%f, name=%s, type=%s)" % (new_state, self._name, self._measurement_type))
 
 class NgenicTempSensor(NgenicSensor):
-    device_class = DEVICE_CLASS_TEMPERATURE
-    state_class  = STATE_CLASS_MEASUREMENT
+    device_class = SensorDeviceClass.TEMPERATURE
+    state_class = SensorStateClass.MEASUREMENT
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
+
+
 class NgenicHumiditySensor(NgenicSensor):
-    device_class = DEVICE_CLASS_HUMIDITY
-    state_class  = STATE_CLASS_MEASUREMENT
+    device_class = SensorDeviceClass.HUMIDITY
+    state_class = SensorStateClass.MEASUREMENT
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
         return "%"
 class NgenicPowerSensor(NgenicSensor):
-    device_class = DEVICE_CLASS_POWER
-    state_class  = STATE_CLASS_MEASUREMENT
+    device_class = SensorDeviceClass.POWER
+    state_class = SensorStateClass.MEASUREMENT
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return POWER_WATT
+        return UnitOfPower.WATT
 
     async def _async_fetch_measurement(self):
         """Fetch new power state data for the sensor.
@@ -340,13 +341,13 @@ class NgenicPowerSensor(NgenicSensor):
         return round(current*1000.0, 1)
         
 class NgenicEnergySensor(NgenicSensor):
-    device_class = DEVICE_CLASS_ENERGY
-    state_class  = STATE_CLASS_TOTAL_INCREASING
+    device_class = SensorDeviceClass.ENERGY
+    state_class = SensorStateClass.TOTAL_INCREASING
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return ENERGY_KILO_WATT_HOUR
+        return UnitOfEnergy.KILO_WATT_HOUR
 
     async def _async_fetch_measurement(self):
         """Ask for measurements for a duration.
@@ -364,12 +365,12 @@ class NgenicEnergySensor(NgenicSensor):
         return "%s %s" % (self._name, "energy")
 
 class NgenicEnergySensorMonth(NgenicSensor):
-    device_class = DEVICE_CLASS_ENERGY
+    device_class = SensorDeviceClass.ENERGY
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return ENERGY_KILO_WATT_HOUR
+        return UnitOfEnergy.KILO_WATT_HOUR
 
     async def _async_fetch_measurement(self):
         """Ask for measurements for a duration.
@@ -392,12 +393,12 @@ class NgenicEnergySensorMonth(NgenicSensor):
         return "%s-%s-%s-month" % (self._node.uuid(), self._measurement_type.name, "sensor")
 
 class NgenicEnergySensorLastMonth(NgenicSensor):
-    device_class = DEVICE_CLASS_ENERGY
+    device_class = SensorDeviceClass.ENERGY
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return ENERGY_KILO_WATT_HOUR
+        return UnitOfEnergy.KILO_WATT_HOUR
 
     async def _async_fetch_measurement(self):
         """Ask for measurements for a duration.

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Ngenic Tune",
   "iot_class": "Cloud Polling",
-  "homeassistant": "2021.9.0"
+  "homeassistant": "2024.4.0"
 }


### PR DESCRIPTION
This fixes all the imports and usage of deprecated fields etc that is mentioned in #47

Also removed the usage of `async_add_job` that was deprecated in HA [2024.4](https://www.home-assistant.io/blog/2024/04/03/release-20244/) as described [here](https://developers.home-assistant.io/blog/2024/03/13/deprecate_add_run_job/) 

Note: The warning `[homeassistant.util.loop] Detected blocking call to load_verify_locations with args (<ssl.SSLContext object at 0x7f9a54f6ba50>,)` seems to be related to an open issue at [HA Core](https://github.com/home-assistant/core/issues/125460)